### PR TITLE
fix windows mocha exec error like:

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -63,7 +63,7 @@ module.exports = (grunt) ->
           '--colors'
           '--recursive'
         ],
-        cmd: './node_modules/.bin/mocha <%= exec.mocha.options.join(" ") %>'
+        cmd: '"./node_modules/.bin/mocha" <%= exec.mocha.options.join(" ") %>'
     keycode:
       generate:
         dest: 'src/adb/keycode.coffee'


### PR DESCRIPTION
use double quotes to correctly reference executable file on Windows.