### PR TITLE
add postinstall task to enable referencing module by github url

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "scripts": {
     "postpublish": "grunt clean",
     "prepublish": "grunt test coffee",
+    "postinstall": "grunt coffee",
     "test": "grunt test"
   },
   "dependencies": {


### PR DESCRIPTION
reference this module by url did not work correctly.

```
	"dependencies": {
		"adbkit": "github:mhama/adbkit",
	},
```

because this module is written in coffeescript and it needs to compile to js to be ready to be used as npm module.
So I added postinstall task to auto-compile to js when this is instaled.
